### PR TITLE
Fix version for sensirion-shdlc-sensorbridge

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,10 @@
 CHANGELOG
 ---------
 
+0.1.1
+:::::
+- Fix allowed version for sensirion-shdlc-sensorbridge
+
 0.1.0
 :::::
 - Initial release of SCD30 I2C driver

--- a/sensirion_i2c_scd30/version.py
+++ b/sensirion_i2c_scd30/version.py
@@ -2,4 +2,4 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import, division, print_function
 
-version = "0.1.0"
+version = "0.1.1"

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ install_requires = [
     'sensirion-i2c-driver',
     'sensirion-i2c-adapter',
     'sensirion_driver_support_types~=0.1.0',
-    'sensirion-shdlc-sensorbridge~=0.1.1'
+    'sensirion-shdlc-sensorbridge>=0.1.1,<0.3.0'
 ]
 
 # Packages required for tests and docs


### PR DESCRIPTION
Sensirion-shdlc-sensorbridge 0.2.0  may be used with this driver.